### PR TITLE
feat: make tsconfig include files complied into serverless too

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,11 +89,11 @@ export class TypeScriptPlugin {
   }
 
   get rootFileNames() {
-    return typescript.extractFileNames(
+    return _.union(typescript.extractFileNames(
       this.originalServicePath,
       this.serverless.service.provider.name,
       this.functions
-    )
+    ), typescript.getTypescriptCompileFiles(this.originalServicePath))
   }
 
   prepare() {

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -82,7 +82,7 @@ export async function run(fileNames: string[], options: ts.CompilerOptions): Pro
     if (!diagnostic.file) {
       console.log(diagnostic)
     }
-    const {line, character} = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start)
+    const { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start)
     const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')
     console.log(`${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`)
   })
@@ -143,4 +143,26 @@ export function getTypescriptConfig(
   }
 
   return makeDefaultTypescriptConfig()
+}
+
+export function getTypescriptCompileFiles(
+  cwd: string,
+): string[] {
+  const configFilePath = path.join(cwd, 'tsconfig.json')
+
+  if (fs.existsSync(configFilePath)) {
+
+    const configFileText = fs.readFileSync(configFilePath).toString()
+    const result = ts.parseConfigFileTextToJson(configFilePath, configFileText)
+    if (result.error) {
+      throw new Error(JSON.stringify(result.error))
+    }
+
+    const configParseResult = ts.parseJsonConfigFileContent(result.config, ts.sys, path.dirname(configFilePath))
+    if (configParseResult.errors.length > 0) {
+      throw new Error(JSON.stringify(configParseResult.errors))
+    }
+    return  configParseResult.fileNames.map(f => f.replace(cwd + '/', ''))
+  }
+  return []
 }

--- a/tests/typescript.getTypescriptCompileFiles.test.ts
+++ b/tests/typescript.getTypescriptCompileFiles.test.ts
@@ -1,0 +1,11 @@
+import {getTypescriptCompileFiles} from '../src/typescript'
+import * as path from 'path'
+describe('getTypescriptCompileFiles', () => {
+    it(`returns all typescript compile files including the tsconfig.json include`, () => {
+        expect(
+          getTypescriptCompileFiles(path.resolve(__dirname, '../'))
+        ).toEqual(
+            ['src/Serverless.d.ts', 'src/index.ts', 'src/typescript.ts', 'src/watchFiles.ts']
+        )
+    })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,9 @@
     "sourceMap": true,
     "outDir": "dist"
   },
+  "include": [
+    "src/**.ts"
+  ],
   "exclude": [
     "node_modules"
   ]


### PR DESCRIPTION
Hi,

This pr fixed issues that tsconfig include files to watch and compile. Please have a look at it and hope this obeys how to contribute.

Reference issues are [Issue 188](https://github.com/prisma-labs/serverless-plugin-typescript/issues/188), [Issue 105](https://github.com/prisma-labs/serverless-plugin-typescript/issues/105)