### PR TITLE
Register `serverless` as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "lodash": "^4.17.11"
   },
   "peerDependencies": {
+    "serverless": "1 || 2",
     "typescript": ">=2.2.2"
   },
   "jest": {


### PR DESCRIPTION
It's to ensure only compatible versions or Framework are used together with a plugin, and if mismatch occurs, user is informed with meaningful error message.

_This PR is part of Serverless Framework initiative to [curate most popular plugins](https://github.com/serverless/serverless/issues/9025)_
