### PR TITLE
Recognize `package.patterns`

### DIFF
--- a/src/Serverless.d.ts
+++ b/src/Serverless.d.ts
@@ -36,6 +36,7 @@ declare namespace Serverless {
   interface Package {
     include: string[]
     exclude: string[]
+    patterns: string[]
     artifact?: string
     individually?: boolean
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,6 +103,7 @@ export class TypeScriptPlugin {
       fn.package = fn.package || {
         exclude: [],
         include: [],
+        patterns: []
       }
 
       // Add plugin to excluded packages or an empty array if exclude is undefined
@@ -157,13 +158,14 @@ export class TypeScriptPlugin {
     return emitedFiles
   }
 
-  /** Link or copy extras such as node_modules or package.include definitions */
+  /** Link or copy extras such as node_modules or package.patterns definitions */
   async copyExtras() {
     const { service } = this.serverless
 
+    const patterns = [...(service.package.include || []), ...(service.package.patterns || [])]
     // include any "extras" from the "include" section
-    if (service.package.include && service.package.include.length > 0) {
-      const files = await globby(service.package.include)
+    if (patterns.length > 0) {
+      const files = await globby(patterns)
 
       for (const filename of files) {
         const destFileName = path.resolve(path.join(BUILD_FOLDER, filename))

--- a/tests/typescript.extractFileName.test.ts
+++ b/tests/typescript.extractFileName.test.ts
@@ -6,21 +6,24 @@ const functions: { [key: string]: Serverless.Function } = {
         handler: 'tests/assets/hello.handler',
         package: {
             include: [],
-            exclude: []
+            exclude: [],
+            patterns: []
         }
     },
     world: {
         handler: 'tests/assets/world.handler',
         package: {
             include: [],
-            exclude: []
+            exclude: [],
+            patterns: []
         }
     },
     js: {
         handler: 'tests/assets/jsfile.create',
         package: {
             include: [],
-            exclude: []
+            exclude: [],
+            patterns: []
         }
     },
 }


### PR DESCRIPTION
Serverless Famework with [v2.32.0](https://github.com/serverless/serverless/releases/tag/v2.32.0) introduce an alternative to `package.include` and `package.exclude` in form of `package.patterns`

To avoid ambiguity support for first two will be dropped with v3, therefore it's important this plugin catches up on that.

Fixes https://github.com/prisma-labs/serverless-plugin-typescript/issues/231
Fixes https://github.com/prisma-labs/serverless-plugin-typescript/issues/240