### PR TITLE
 Fix resolution of `invoke local`  related lifecycle hook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,10 +66,9 @@ export class TypeScriptPlugin {
           })
         }
       },
-      'after:invoke:local:invoke': () => {
+      'after:invoke:local:invoke': async () => {
         if (this.options.watch) {
-          this.watchFunction()
-          this.serverless.cli.log('Waiting for changes...')
+          await this.watchFunction()
         }
       }
     }
@@ -117,10 +116,13 @@ export class TypeScriptPlugin {
     }
 
     this.serverless.cli.log(`Watch function ${this.options.function}...`)
+    this.serverless.cli.log('Waiting for changes...')
 
     this.isWatching = true
-    watchFiles(this.rootFileNames, this.originalServicePath, () => {
-      this.serverless.pluginManager.spawn('invoke:local')
+    await new Promise((resolve, reject) => {
+      watchFiles(this.rootFileNames, this.originalServicePath, () => {
+        this.serverless.pluginManager.spawn('invoke:local').catch(reject)
+      })
     })
   }
 


### PR DESCRIPTION
Currently when ` invoke local` is run with `--watch` option, command resolves instantly, signalling to the Framework that invocation ended, while watching remains to be in progress.

This patch ensures that the command doesn't resolve internally until the watch is either stopped manually or crashes