### PR TITLE
fix: Adding Serverless Layers Support

### DIFF
--- a/src/Serverless.d.ts
+++ b/src/Serverless.d.ts
@@ -18,7 +18,7 @@ declare namespace Serverless {
       layers: { [key: string]: Serverless.Layer }
       package: Serverless.Package
       getAllFunctions(): string[]
-      getAllLayers: () => string[]
+      getAllLayers(): string[]
       custom?: {
         serverlessPluginTypescript?: {
           tsConfigFileLocation: string

--- a/src/Serverless.d.ts
+++ b/src/Serverless.d.ts
@@ -15,8 +15,10 @@ declare namespace Serverless {
       functions: {
         [key: string]: Serverless.Function
       }
+      layers: { [key: string]: Serverless.Layer }
       package: Serverless.Package
       getAllFunctions(): string[]
+      getAllLayers: () => string[]
       custom?: {
         serverlessPluginTypescript?: {
           tsConfigFileLocation: string
@@ -34,6 +36,11 @@ declare namespace Serverless {
   }
 
   interface Function {
+    handler: string
+    package: Serverless.Package
+  }
+
+  interface Layer {
     handler: string
     package: Serverless.Package
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -277,7 +277,7 @@ export class TypeScriptPlugin {
           SERVERLESS_FOLDER,
           path.basename(service.functions[name].package.artifact)
         )
-      })      
+      })
       return
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -250,6 +250,15 @@ export class TypeScriptPlugin {
       path.join(this.originalServicePath, SERVERLESS_FOLDER)
     )
 
+    const layerNames = service.getAllLayers()
+    layerNames.forEach(name => {
+      service.layers[name].package.artifact = path.join(
+        this.originalServicePath,
+        SERVERLESS_FOLDER,
+        path.basename(service.layers[name].package.artifact)
+      )
+    })
+
     if (this.options.function) {
       const fn = service.functions[this.options.function]
       fn.package.artifact = path.join(
@@ -268,15 +277,7 @@ export class TypeScriptPlugin {
           SERVERLESS_FOLDER,
           path.basename(service.functions[name].package.artifact)
         )
-      })
-      const layerNames = service.getAllLayers()
-      layerNames.forEach(name => {
-        service.layers[name].package.artifact = path.join(
-          this.originalServicePath,
-          SERVERLESS_FOLDER,
-          path.basename(service.layers[name].package.artifact)
-        )
-      })
+      })      
       return
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -269,6 +269,14 @@ export class TypeScriptPlugin {
           path.basename(service.functions[name].package.artifact)
         )
       })
+      const layerNames = service.getAllLayers()
+      layerNames.forEach(name => {
+        service.layers[name].package.artifact = path.join(
+          this.originalServicePath,
+          SERVERLESS_FOLDER,
+          path.basename(service.layers[name].package.artifact)
+        )
+      })
       return
     }
 


### PR DESCRIPTION
Adding support for layers, since they currently break on packaging because serverless is looking for the layers files in the delete `.build` directory.

Based off this pull request from years ago: https://github.com/serverless/serverless-plugin-typescript/pull/128

This resolves this issue: https://github.com/serverless/serverless-plugin-typescript/issues/240
