### PR TITLE
Fix #271 Skip Non-NodeJS Functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,13 +53,13 @@
     "@types/jest": "24.0.12",
     "@types/lodash": "4.14.123",
     "@types/node": "12.6.2",
-    "jest": "24.5.0",
+    "jest": "28.1.3",
     "mock-fs": "4.9.0",
     "rimraf": "2.6.3",
     "standard-version": "^9.3.2",
-    "ts-jest": "24.0.2",
+    "ts-jest": "28.0.7",
     "tslint": "5.14.0",
-    "typescript": "^3.9.10"
+    "typescript": "^4.7.4"
   },
   "dependencies": {
     "fs-extra": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -53,11 +53,11 @@
     "@types/jest": "24.0.12",
     "@types/lodash": "4.14.123",
     "@types/node": "12.6.2",
-    "jest": "28.1.3",
+    "jest": "24.5.0",
     "mock-fs": "4.9.0",
     "rimraf": "2.6.3",
     "standard-version": "^9.3.2",
-    "ts-jest": "28.0.7",
+    "ts-jest": "24.0.2",
     "tslint": "5.14.0",
     "typescript": "^4.7.4"
   },

--- a/src/Serverless.d.ts
+++ b/src/Serverless.d.ts
@@ -11,6 +11,7 @@ declare namespace Serverless {
     service: {
       provider: {
         name: string
+        runtime?: string
       }
       functions: {
         [key: string]: Serverless.Function
@@ -38,6 +39,7 @@ declare namespace Serverless {
   interface Function {
     handler: string
     package: Serverless.Package
+    runtime?: string
   }
 
   interface Layer {

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,14 +93,25 @@ export class TypeScriptPlugin {
   get functions() {
     const { options } = this
     const { service } = this.serverless
+    const functions = service.functions || {}
 
-    if (options.function) {
+    const nodeFunctions = Object.keys(functions)
+      .filter(functionKey => {
+        const runtime = functions[functionKey].runtime || service.provider.runtime
+        return runtime.includes('nodejs')
+      })
+      .reduce((obj, key) => {
+        obj[key] = functions[key]
+        return obj
+    }, {})
+
+    if (options.function && nodeFunctions[options.function]) {
       return {
-        [options.function]: service.functions[this.options.function]
+        [options.function]: nodeFunctions[options.function]
       }
     }
 
-    return service.functions
+    return nodeFunctions
   }
 
   get rootFileNames() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,15 +95,13 @@ export class TypeScriptPlugin {
     const { service } = this.serverless
     const functions = service.functions || {}
 
-    const nodeFunctions = Object.keys(functions)
-      .filter(functionKey => {
-        const runtime = functions[functionKey].runtime || service.provider.runtime
-        return runtime.includes('nodejs')
-      })
-      .reduce((obj, key) => {
-        obj[key] = functions[key]
-        return obj
-    }, {})
+    const nodeFunctions = {}
+    for (const [name, functionObject] of Object.entries(functions)) {
+      const runtime = functions[name].runtime || service.provider.runtime
+      if (runtime.includes('nodejs')) {
+        nodeFunctions[name] = functionObject
+      }
+    }
 
     if (options.function && nodeFunctions[options.function]) {
       return {

--- a/tests/typescript.extractFileName.test.ts
+++ b/tests/typescript.extractFileName.test.ts
@@ -4,6 +4,7 @@ import * as path from 'path'
 const functions: { [key: string]: Serverless.Function } = {
     hello: {
         handler: 'tests/assets/hello.handler',
+        runtime: 'nodejs10.1',
         package: {
             include: [],
             exclude: [],
@@ -12,6 +13,7 @@ const functions: { [key: string]: Serverless.Function } = {
     },
     world: {
         handler: 'tests/assets/world.handler',
+        runtime: 'nodejs10.1',
         package: {
             include: [],
             exclude: [],
@@ -20,6 +22,7 @@ const functions: { [key: string]: Serverless.Function } = {
     },
     js: {
         handler: 'tests/assets/jsfile.create',
+        runtime: 'nodejs10.1',
         package: {
             include: [],
             exclude: [],

--- a/tests/typescript.pluginSkipNonNode.test.ts
+++ b/tests/typescript.pluginSkipNonNode.test.ts
@@ -1,0 +1,61 @@
+import * as TypeScriptPlugin from '../src/index'
+
+describe('TypeScriptPlugin', () => {
+    it('rootFileNames includes only node runtimes', () => {
+        const slsInstance: Serverless.Instance = {
+            cli: {
+              log: jest.fn()
+            },
+            config: {
+              servicePath: 'servicePath'
+            },
+            service: {
+              provider: {
+                name: 'aws',
+                runtime: 'nodejs99'
+              },
+              functions: {
+                func1: {
+                    handler: 'java-fn',
+                    runtime: 'python3.9',
+                    package:{
+                        exclude: [],
+                        include: [],
+                        patterns: []
+                    }
+                },
+                func2: {
+                    handler: 'node-fn',
+                    runtime: 'nodejs16',
+                    package:{
+                        exclude: [],
+                        include: [],
+                        patterns: []
+                    }
+                }
+              },
+              package: {
+                exclude: [],
+                include: [],
+                patterns: []
+              },
+              layers: {},
+              getAllLayers: jest.fn(),
+              getAllFunctions: jest.fn()
+            },
+            pluginManager: {
+                spawn: jest.fn()
+            }
+          }
+
+        const plugin = new (TypeScriptPlugin as any)(slsInstance, {})
+
+        expect(
+            Object.keys(plugin.functions)
+        ).toEqual(
+            [
+                'func2'
+            ],
+        )
+    })
+})


### PR DESCRIPTION
This plugin currently breaks your serverless stack if you have any non-nodejs functions (Python, Java, etc.) also in it. This skips them
This is based on this old PR: #197 (Merge conflicts and some unnecessary changes)
This closes #271

Change summary:
- Update to typescript 4.* (fixes tsc error I was getting before making any changes, I can revert if you don't want this update)
- Only grab functions of nodejs type (Fixes error this causes for non-nodejs functions)
- Add test (copied from #197)