### PR TITLE
Fix issue #219

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -228,7 +228,7 @@ export class TypeScriptPlugin {
     // copy development dependencies during packaging
     if (isPackaging) {
       if (fs.existsSync(outModulesPath)) {
-        fs.unlinkSync(outModulesPath)
+        fs.removeSync(outModulesPath)
       }
 
       fs.copySync(


### PR DESCRIPTION
This fix replaces `fs.unlinkSync` with `fs.removeSync`, as `fs.removeSync` should not be used on directories (such as 'node_modules'). 

This solves issues that can occur when running `sls deploy`.