### PR TITLE
Fix #272: symlink deps are not included in the build

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -210,7 +210,7 @@ export class TypeScriptPlugin {
         }
 
         if (!fs.existsSync(destFileName)) {
-          fs.copySync(path.resolve(filename), path.resolve(path.join(BUILD_FOLDER, filename)))
+          fs.copySync(path.resolve(filename), path.resolve(path.join(BUILD_FOLDER, filename)), { dereference: true })
         }
       }
     }
@@ -233,7 +233,8 @@ export class TypeScriptPlugin {
 
       fs.copySync(
         path.resolve('node_modules'),
-        path.resolve(path.join(BUILD_FOLDER, 'node_modules'))
+        path.resolve(path.join(BUILD_FOLDER, 'node_modules')),
+        { dereference: true }
       )
     } else {
       if (!fs.existsSync(outModulesPath)) {


### PR DESCRIPTION
As mentioned in issue #272, the symlink deps are not included in the build. 

This PR is to copy symlink dependencies to the build package using the `dereference` feature from the `fs.copySync`.