### PR TITLE
Fix #280: support docker lambdas

### DIFF
--- a/src/Serverless.d.ts
+++ b/src/Serverless.d.ts
@@ -37,11 +37,15 @@ declare namespace Serverless {
   }
 
   interface Function {
-    handler: string
+    handler?: string
     package: Serverless.Package
     runtime?: string
+    image?: Serverless.Image
   }
 
+  interface Image {
+    name: string
+  }
   interface Layer {
     handler: string
     package: Serverless.Package

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -48,6 +48,7 @@ export function extractFileNames(cwd: string, provider: string, functions?: { [k
 
   return _.values(functions)
     .map(fn => fn.handler)
+    .filter(Boolean)
     .map(h => {
       const fnName = _.last(h.split('.'))
       const fnNameLastAppearanceIndex = h.lastIndexOf(fnName)

--- a/tests/typescript.extractFileName.test.ts
+++ b/tests/typescript.extractFileName.test.ts
@@ -29,6 +29,16 @@ const functions: { [key: string]: Serverless.Function } = {
             patterns: []
         }
     },
+    dockerBasedFunction: {
+        image: {
+            name: 'path/to/lambda/image'
+        },
+        package: {
+            include: [],
+            exclude: [],
+            patterns: []
+        }
+    }
 }
 
 describe('extractFileName', () => {


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1y7I1v5SWrTtSYihMVXyH09utfM94CLI0%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=rXwqv21)

Fixes [#280](https://github.com/serverless/serverless-plugin-typescript/issues/280)

in order to support container Image for AWS Lambda, the `handler` attribute in function is no longer a mandatory one and can be replaced with `image` attribute.

- [x] Tested locally
- [x] Add tests