### PR TITLE
fix: make tsconfig include files compilation honour tsConfigFileLocation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,7 @@ export class TypeScriptPlugin {
       this.originalServicePath,
       this.serverless.service.provider.name,
       this.functions
-    ), typescript.getTypescriptCompileFiles(this.originalServicePath))
+    ), typescript.getTypescriptCompileFiles(this.originalServicePath, this.getTsConfigFileLocation()))
   }
 
   prepare() {
@@ -162,6 +162,17 @@ export class TypeScriptPlugin {
     watchFiles(this.rootFileNames, this.originalServicePath, this.compileTs.bind(this))
   }
 
+  getTsConfigFileLocation() {
+    let tsConfigFileLocation
+    if (
+      this.serverless.service.custom !== undefined
+      && this.serverless.service.custom.serverlessPluginTypescript !== undefined
+    ) {
+      tsConfigFileLocation = this.serverless.service.custom.serverlessPluginTypescript.tsConfigFileLocation
+    }
+    return tsConfigFileLocation ?? 'tsconfig.json'
+  }
+
   async compileTs(): Promise<string[]> {
     this.prepare()
     this.serverless.cli.log('Compiling with Typescript...')
@@ -172,16 +183,10 @@ export class TypeScriptPlugin {
       // Fake service path so that serverless will know what to zip
       this.serverless.config.servicePath = path.join(this.originalServicePath, BUILD_FOLDER)
     }
-    let tsConfigFileLocation: string | undefined
-    if (
-      this.serverless.service.custom !== undefined
-      && this.serverless.service.custom.serverlessPluginTypescript !== undefined
-    ) {
-      tsConfigFileLocation = this.serverless.service.custom.serverlessPluginTypescript.tsConfigFileLocation
-    }
+
     const tsconfig = typescript.getTypescriptConfig(
       this.originalServicePath,
-      tsConfigFileLocation,
+      this.getTsConfigFileLocation(),
       this.isWatching ? null : this.serverless.cli
     )
 

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -150,9 +150,9 @@ export function getTypescriptConfig(
 }
 
 export function getTypescriptCompileFiles(
-  cwd: string,
+  cwd: string, tsConfigFileLocation: string
 ): string[] {
-  const configFilePath = path.join(cwd, 'tsconfig.json')
+  const configFilePath = path.join(cwd, tsConfigFileLocation)
 
   if (fs.existsSync(configFilePath)) {
 

--- a/tests/typescript.getTypescriptCompileFiles.test.ts
+++ b/tests/typescript.getTypescriptCompileFiles.test.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 describe('getTypescriptCompileFiles', () => {
     it(`returns all typescript compile files including the tsconfig.json include`, () => {
         expect(
-          getTypescriptCompileFiles(path.resolve(__dirname, '../'))
+          getTypescriptCompileFiles(path.resolve(__dirname, '../'), 'tsconfig.json')
         ).toEqual(
             ['src/Serverless.d.ts', 'src/index.ts', 'src/typescript.ts', 'src/watchFiles.ts']
         )


### PR DESCRIPTION
Closes: https://github.com/serverless/serverless-plugin-typescript/issues/296