### PR TITLE
chore: upgrade `globby` to 11.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "fs-extra": "^7.0.1",
-    "globby": "^10.0.2",
+    "globby": "^11.0.4",
     "lodash": "^4.17.21"
   },
   "peerDependencies": {


### PR DESCRIPTION
[`globby`](https://github.com/sindresorhus/globby) v10.0.2 depends on `@types/glob`, and it can cause TS issues.
v11 wil resolve this problem by dropping the glob dependencies.
- https://github.com/sindresorhus/globby/releases/tag/v11.0.0