### PR TITLE
Enhance error logging for file not found exceptions

### DIFF
--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -66,7 +66,7 @@ export function extractFileNames(cwd: string, provider: string, functions?: { [k
 
       // Can't find the files. Watch will have an exception anyway. So throw one with error.
       console.log(`Cannot locate handler - ${fileName} not found`)
-      throw new Error('Typescript compilation failed. Please ensure handlers exists with ext .ts or .js')
+      throw new Error(`Typescript compilation failed. Please ensure ${fileName} exists with ext .ts or .js`);
     })
 }
 

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -65,7 +65,6 @@ export function extractFileNames(cwd: string, provider: string, functions?: { [k
       }
 
       // Can't find the files. Watch will have an exception anyway. So throw one with error.
-      console.log(`Cannot locate handler - ${fileName} not found`)
       throw new Error(`Typescript compilation failed. Please ensure ${fileName} exists with ext .ts or .js`);
     })
 }


### PR DESCRIPTION
Currently, when the handler file cannot be found, only the exact file path is printed out in the console.log. 

It would be more convenient to include the exact path in the actual error message for easier troubleshooting.