### PR TITLE
Fix #240: No file matches include / exclude patterns when using Layers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -189,6 +189,10 @@ export class TypeScriptPlugin {
 
     const emitedFiles = await typescript.run(this.rootFileNames, tsconfig)
     this.serverless.cli.log('Typescript compiled.')
+
+    // Restore service path
+    this.serverless.config.servicePath = this.originalServicePath;
+
     return emitedFiles
   }
 


### PR DESCRIPTION
In `compileTs`, `this.serverless.config.servicePath` was being overwritten, but it was left in place after the build was complete, affecting later processing.
Fixed by reassigning the `originalServicePath`.