### PR TITLE
Don't try to access properties of undefined diagnostic file object

### DIFF
--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -81,10 +81,11 @@ export async function run(fileNames: string[], options: ts.CompilerOptions): Pro
   allDiagnostics.forEach(diagnostic => {
     if (!diagnostic.file) {
       console.log(diagnostic)
+    } else {
+      const { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start)
+      const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')
+      console.log(`${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`)
     }
-    const { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start)
-    const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')
-    console.log(`${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`)
   })
 
   if (emitResult.emitSkipped) {


### PR DESCRIPTION
When compiling with node20.x or node22.x, I got this error:

```
{
  file: undefined,
  start: undefined,
  length: undefined,
  code: 2688,
  category: 1,
  messageText: {
    messageText: "Cannot find type definition file for 'glob'.",
    category: 1,
    code: 2688,
    next: [ [Object] ]
  },
  relatedInformation: undefined
}

Error:
TypeError: Cannot read properties of undefined (reading 'getLineAndCharacterOfPosition')
    at node_modules/serverless-plugin-typescript/dist/src/typescript.js:85:57
```